### PR TITLE
Post-login warmup timer for rewards

### DIFF
--- a/src/main/java/gq/bxteam/ndailyrewards/cfg/Config.java
+++ b/src/main/java/gq/bxteam/ndailyrewards/cfg/Config.java
@@ -32,6 +32,7 @@ public class Config {
     public static boolean opt_midnight;
     public static boolean opt_metrics;
     public static int opt_cd;
+    public static int opt_wm;
     public static int opt_grd;
     public static int opt_days_row;
     public static Map<Integer, Reward> rewards;
@@ -66,6 +67,7 @@ public class Config {
         Config.opt_midnight = cfg.getBoolean(path + "unlock-after-midnight");
         Config.opt_metrics = cfg.getBoolean(path + "enable-metrics");
         Config.opt_cd = cfg.getInt(path + "rewards-cool-down", 86400);
+        Config.opt_wm = cfg.getInt(path + "reward-login-delay", 0);
         Config.opt_grd = cfg.getInt(path + "gui-refresh-delay", 5);
         Config.opt_days_row = cfg.getInt(path + "days-row");
         Config.rewards = new TreeMap<Integer, Reward>();
@@ -105,7 +107,8 @@ public class Config {
         final ItemStack day_taken = cfg.getItemFromSection(path + "days-display.taken");
         final ItemStack day_locked = cfg.getItemFromSection(path + "days-display.locked");
         final ItemStack day_next = cfg.getItemFromSection(path + "days-display.next");
-        Config.rewards_gui = new RewardGUI(NDailyRewards.getInstance(), g_title, g_size, g_items, slots, day_ready, day_taken, day_locked, day_next);
+        final ItemStack day_warmup = cfg.getItemFromSection(path + "days-display.warmup");
+        Config.rewards_gui = new RewardGUI(NDailyRewards.getInstance(), g_title, g_size, g_items, slots, day_ready, day_taken, day_locked, day_next, day_warmup);
     }
 
     public static Reward getRewardByDay(final int day) {

--- a/src/main/java/gq/bxteam/ndailyrewards/hooks/external/PlaceholderExpansions.java
+++ b/src/main/java/gq/bxteam/ndailyrewards/hooks/external/PlaceholderExpansions.java
@@ -42,6 +42,13 @@ public class PlaceholderExpansions extends me.clip.placeholderapi.expansion.Plac
             return new java.text.SimpleDateFormat(format).format(new java.util.Date(Long.parseLong(unix)));
         }
 
+        if (identifier.equalsIgnoreCase("warmup_reward_time")) {
+            String unix = String.valueOf(new DUser(Objects.requireNonNull(player.getPlayer())).remainingLoginDuration());
+            String format = this.getString("date_format", "dd/MM/yyyy hh:mma");
+
+            return new java.text.SimpleDateFormat(format).format(new java.util.Date(Long.parseLong(unix)));
+        }
+
         return null;
     }
 }

--- a/src/main/java/gq/bxteam/ndailyrewards/manager/objects/DUser.java
+++ b/src/main/java/gq/bxteam/ndailyrewards/manager/objects/DUser.java
@@ -109,4 +109,37 @@ public class DUser {
         }
         return Config.opt_cd * 1000L;
     }
+
+    public boolean pastLoginDurationThreshold() {
+        // Get the current system time
+        long currentTime = System.currentTimeMillis();
+
+        // Calculate the login time plus the duration threshold
+        long thresholdTime = login + (Config.opt_wm * 1000); // Convert seconds to milliseconds
+
+        // Check if the current time is past the threshold time
+        boolean isPastThreshold = currentTime > thresholdTime;
+
+        return isPastThreshold;
+    }
+
+    public long remainingLoginDuration() {
+        // Get the current system time
+        long currentTime = System.currentTimeMillis();
+
+        // Calculate the login time plus the duration threshold
+        long thresholdTime = login + (Config.opt_wm * 1000); // Convert seconds to milliseconds
+
+        // Check if the current time is past the threshold time
+        long difference = thresholdTime - currentTime;
+
+        return difference;
+    }
+
+    public long warmupDurationUntil() {
+        // Calculate the login time plus the duration threshold
+        long thresholdTime = login + (Config.opt_wm * 1000); // Convert seconds to milliseconds
+
+        return thresholdTime;
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,9 +27,12 @@ options:
     enabled: true
     only-when-have: true
   days-row: 7
+  # Time in seconds
   rewards-cool-down: 86400
   gui-refresh-delay: 5
   unlock-after-midnight: false
+  # Time in seconds
+  reward-login-delay: 0
   enable-metrics: true
 rewards:
   '1':
@@ -158,6 +161,13 @@ gui:
         - '%reward-lore%'
         - ''
         - '&c» &7Claim the previous reward to unlock!'
+    warmup:
+      material: 'IRON_BLOCK:0:1'
+      name: '&c[Day #%day%] &7Time-Locked Reward'
+      lore:
+        - '%reward-lore%'
+        - ''
+        - '&c» &7Wait until &e%reward-warmup-remaining% &7 to unlock!'
     next:
       material: 'GOLD_BLOCK:0:1'
       name: '&e[Day #%day%] &7Awaiting...'
@@ -177,6 +187,6 @@ gui:
         - '&aThe more days in a row you'
         - '&ajoin the better the reward!'
         - ''
-        - '&cYou must wait: &7%time%'
+        - '&cYou must wait: &7%time-warmupfactored%'
         - '&cbefore claiming your next bonus'
       slots: 0,1,2,3,4,5,6,7,8,9,17,18,19,20,21,22,23,24,25,26


### PR DESCRIPTION
This PR adds a configurable setting to have a warmup period required after login before reward can be claimed.

Changes in config.yml:
In `days-display`
`    warmup:

      material: IRON_BLOCK:0:1

      name: '&c[Day #%day%] &7Time-Locked Reward'

      lore:

      - '%reward-lore%'

      - ''
      - 
      - '&c» &7Wait until &e%reward-warmup-remaining% &7while online to unlock!'`
      
In `options`
`reward-login-delay: 0`

Both setting changes follow the conventions established by other configuration options, feel free to let me know if there is anything off with this PR or improvements that could be made.